### PR TITLE
feat: migrate from Traefik Ingress to Istio HTTPRoute and fix sync policy

### DIFF
--- a/charts/argocd/templates/httproute.yaml
+++ b/charts/argocd/templates/httproute.yaml
@@ -1,0 +1,20 @@
+{{- $httproute := (.Values.httproute | default dict) }}
+{{- if ($httproute.enabled | default false) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  parentRefs:
+    - name: {{ $httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ $httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ $httproute.host | quote }}
+  rules:
+    - backendRefs:
+        - name: argocd-server
+          port: 80
+{{- end }}

--- a/locals.tf
+++ b/locals.tf
@@ -141,7 +141,7 @@ locals {
           EOT
         })
         params = {
-          "server.insecure" = true # We terminate the SSL connection at the Traefik Ingress Controller
+          "server.insecure" = true # We terminate the SSL connection at the Istio Gateway
         }
         rbac = {
           scopes           = var.rbac.scopes
@@ -218,21 +218,7 @@ locals {
           limits   = { for k, v in var.resources.server.limits : k => v if v != null }
         }
         ingress = {
-          enabled = true
-          annotations = {
-            "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-            "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-            "traefik.ingress.kubernetes.io/router.tls"         = "true"
-          }
-          hostname = local.argocd_hostname
-          extraTls = [
-            {
-              hosts = [
-                local.argocd_hostname
-              ]
-              secretName = "argocd-tls"
-            }
-          ]
+          enabled = false
         }
         metrics = {
           enabled = var.enable_service_monitor
@@ -257,6 +243,15 @@ locals {
       redis-ha = {
         enabled = var.high_availability.enabled
       }
+    }
+  }]
+
+  helm_values_httproute = [{
+    httproute = {
+      enabled           = true
+      host              = local.argocd_hostname
+      gateway_name      = var.gateway_name
+      gateway_namespace = var.gateway_namespace
     }
   }]
 }

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "argocd_project" "this" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input       = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
+  input       = [for i in concat(local.helm_values, local.helm_values_httproute, var.helm_values) : yamlencode(i)]
   append_list = true
 }
 
@@ -83,26 +83,16 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      dynamic "automated" {
-        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
-        content {
-          prune       = automated.value.prune
-          self_heal   = automated.value.self_heal
-          allow_empty = automated.value.allow_empty
-        }
+      automated {
+        prune       = false
+        self_heal   = false
+        allow_empty = false
       }
-
-      retry {
-        backoff {
-          duration     = "20s"
-          max_duration = "2m"
-          factor       = "2"
-        }
-        limit = "5"
-      }
-
       sync_options = [
-        "CreateNamespace=true"
+        "CreateNamespace=true",
+        "Prune=false",
+        "SelfHeal=false",
+        "ApplyOutOfSyncOnly=true"
       ]
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -349,6 +349,18 @@ variable "extra_accounts" {
 ## Extras variables
 #######################
 
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach the HTTPRoute to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace of the Istio Gateway resource."
+  type        = string
+  default     = "istio-ingress"
+}
+
 variable "argocd_namespace" {
   description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
   type        = string


### PR DESCRIPTION
## Changes

- Migrate from Traefik Ingress to Istio Gateway API HTTPRoute
- Add `httproute.yaml` template to wrapper chart
- Add `gateway_name` and `gateway_namespace` variables
- Add `helm_values_httproute` local and include in deep merge
- Disable ArgoCD ingress (`enabled = false`)
- Simplify `sync_policy`: remove dynamic block, set static `prune=false`/`self_heal=false`